### PR TITLE
Bugfix venv creation using relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ Tip: use the latest version of python you have available.
 ### Notes
 - Conda environments may experience issues installing with `ssl` DLL issues.
 See this [StackOverflow resource](https://stackoverflow.com/questions/54175042/python-3-7-anaconda-environment-import-ssl-dll-load-fail-error/60405693#60405693) 
+and this repository's corresponding [GitHub Issue](https://github.com/cooperjaXC/windows-python-venv/issues/4)
 for more help.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ Tip: use the latest version of python you have available.
 
 ### Notes
 - Conda environments may experience issues installing with `ssl` DLL issues.
+See this [StackOverflow resource](https://stackoverflow.com/questions/54175042/python-3-7-anaconda-environment-import-ssl-dll-load-fail-error/60405693#60405693) 
+for more help.

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,3 @@
 # Note: `requirements.in` can accept comments.
 typer
 icecream
-# ccaoa  # Internal Child Care Aware of America repository. See https://github.com/ccaoa/ccaoa-mapping
-git+ssh://git@github.com/ccaoa/ccaoa-mapping.git#egg=ccaoa

--- a/setup.bat
+++ b/setup.bat
@@ -1,7 +1,8 @@
-:: Set your root directory that houses your virtual environment content.
-::@set VENV_DIR=.
-:: Or, set the default directory to be the path where this .bat file is located.
-@set VENV_DIR=%~dp0
-@call %VENV_DIR%\set_python_path.bat
+:: Establish your local root python path.
+:: Set the default for this to be the directory this .bat file is housed within.
+set "VENV_DIR=%~dp0"
+:: The `@` symbol at the beginning of a command in a batch file is used to prevent the command line from being echoed (displayed) in the console.
+:: :: It does not affect the execution of the command itself.
+@call "%VENV_DIR%\set_python_path.bat"
 :: Set up the virtual environment using the base interpreter.
-@%PYTHON_PATH% %VENV_DIR%\setup.py
+@%PYTHON_PATH% "%VENV_DIR%\setup.py"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ from sys import executable
 import ensurepip
 
 # Use __file__ if it's defined, otherwise default to the current working directory
-py_venv_dir = Path(__file__).parent if '__file__' in locals() else Path('.')
+py_venv_dir = Path(__file__).parent if "__file__" in locals() else Path(".")
 # Construct the path to the 'venv' directory relative to the script's location
 VENV_PATH = py_venv_dir / "venv"
 VENV_PATH = VENV_PATH.resolve()
@@ -171,7 +171,8 @@ def main() -> None:
     # The requirements.txt file defaults to being located inside the "./py_venv" directory.
     # # This is so that the user can find the full requirements readout after the venv is created,
     # # but it is not confusingly included at the project-level directory.
-    requirements_txt_path = py_venv_dir / "requirements.txt"  # Path("./py_venv/requirements.txt")
+    # requirements_txt_path = Path("./py_venv/requirements.txt")
+    requirements_txt_path = py_venv_dir / "requirements.txt"
     # Search for existing instances of `requirements.txt`
     if not requirements_txt_path.exists():
         # The root directory will become the default location for the requirements.txt whether it exists or not.
@@ -189,7 +190,9 @@ def main() -> None:
         # print(f"\nExecuting venv creation command: {command}")
         run(command)
         # print(f"\nExecuting activate venv command: {activate}\n")
-        run(f"{activate} python -m pip install --upgrade pip setuptools wheel pip-tools")
+        run(
+            f"{activate} python -m pip install --upgrade pip setuptools wheel pip-tools"
+        )
     except subprocess.CalledProcessError:
         # There is an issue establishing the venv.
         # # With ArcGIS Pro base python interpreters, this often has to do with the ensurepip pip wheel.
@@ -208,7 +211,7 @@ def main() -> None:
             f'{activate} python "{whl}"/pip install --upgrade pip setuptools wheel pip-tools'
         )
     # print("Made it to the Activate stage")
-    pip_install_command = f"{activate}python -m pip install -r \"{requirements_in_path}\""
+    pip_install_command = f'{activate}python -m pip install -r "{requirements_in_path}"'
     print(f"\nExecuting pip install command: {pip_install_command}\n")
     run(pip_install_command)
     run(f'{activate} python -m pip freeze > "{requirements_txt_path}"')


### PR DESCRIPTION
This will fully implement the enhancement in Issue #3 as well as fix bugs in the current `setup.bat` that unsuccessfully uses relative paths.

All paths are now assigned relatively in the VENV creation in both `setup.bat` and `setup.py` for minimal user hard-coding before use. 